### PR TITLE
add .idea folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea


### PR DESCRIPTION
## What

add `.idea` folder to gitignore

## Why

[.idea is user-specific](https://www.jetbrains.com/help/idea/creating-and-managing-projects.html#directory-based), hence it should not be in VCS